### PR TITLE
Fix Level Length Check

### DIFF
--- a/src/main/java/org/photonvision/mrcal/MrCalJNI.java
+++ b/src/main/java/org/photonvision/mrcal/MrCalJNI.java
@@ -77,6 +77,11 @@ public class MrCalJNI {
             for (var c : corners) {
                 float level = 1.0f; // if we have mrgingham, use level from that. Otherwise, hard-coded to 1
 
+                if(c.x == -1 && c.y ==-1) // (-1,-1) is impossible and we should ignore this point.
+                {
+                    level = -1.0f;
+                }
+
                 observations[i * 3 + 0] = c.x;
                 observations[i * 3 + 1] = c.y;
                 observations[i * 3 + 2] = level;

--- a/src/main/java/org/photonvision/mrcal/MrCalJNI.java
+++ b/src/main/java/org/photonvision/mrcal/MrCalJNI.java
@@ -72,7 +72,7 @@ public class MrCalJNI {
                 int imageWidth, int imageHeight, double focalLen) {
             double[] observations = new double[boardWidth * boardHeight * 3 * board_corners.size()];
 
-            if (board_corners.size() != board_corner_levels.size()) {
+            if (board_corners.size() != board_corner_levels.size() && board_corners.size() == boardWidth*boardHeight) {
                 return new MrCalResult(false);
             }
 
@@ -81,11 +81,14 @@ public class MrCalJNI {
                 var board = board_corners.get(b);
                 var levels = board_corner_levels.get(b).toArray();
                 var corners = board.toArray();
+                
+                if (corners.length != levels.length && corners.length == boardWidth*boardHeight) {
+                    return new MrCalResult(false);
+                }
+
                 // Assume that we're correct in terms of row/column major-ness (lol)
                 for (int c = 0; c < corners.length; c++) {
-                    if (corners.length != levels.length) {
-                        return new MrCalResult(false);
-                    }
+
                     var corner = corners[c];
                     float level = levels[c];
 

--- a/src/main/java/org/photonvision/mrcal/MrCalJNI.java
+++ b/src/main/java/org/photonvision/mrcal/MrCalJNI.java
@@ -65,49 +65,45 @@ public class MrCalJNI {
     public static native boolean undistort_mrcal(long srcMat, long dstMat, long cameraMat, long distCoeffsMat,
             int lensModelOrdinal, int order, int Nx, int Ny, int fov_x_deg);
 
-            public static MrCalResult calibrateCamera(
-                List<MatOfPoint2f> board_corners,
-                List<MatOfFloat> board_corner_levels,
-                int boardWidth, int boardHeight, double boardSpacing,
-                int imageWidth, int imageHeight, double focalLen) {
-            double[] observations = new double[boardWidth * boardHeight * 3 * board_corners.size()];
+    public static MrCalResult calibrateCamera(
+            List<MatOfPoint2f> board_corners,
+            List<MatOfFloat> board_corner_levels,
+            int boardWidth, int boardHeight, double boardSpacing,
+            int imageWidth, int imageHeight, double focalLen) {
+        double[] observations = new double[boardWidth * boardHeight * 3 * board_corners.size()];
 
-            if (board_corners.size() != board_corner_levels.size() && board_corners.size() == boardWidth*boardHeight) {
-                return new MrCalResult(false);
-            }
-
-            int i = 0;
-            for (int b = 0; b < board_corners.size(); b++) {
-                var board = board_corners.get(b);
-                var levels = board_corner_levels.get(b).toArray();
-                var corners = board.toArray();
-                
-                if (corners.length != levels.length && corners.length == boardWidth*boardHeight) {
-                    return new MrCalResult(false);
-                }
-
-                // Assume that we're correct in terms of row/column major-ness (lol)
-                for (int c = 0; c < corners.length; c++) {
-
-                    var corner = corners[c];
-                    float level = levels[c];
-
-                    observations[i * 3 + 0] = corner.x;
-                    observations[i * 3 + 1] = corner.y;
-                    observations[i * 3 + 2] = level;
-
-                    i += 1;
-                }
-            }
-
-            if (i * 3 != observations.length)
-
-            {
-                return new MrCalResult(false);
-            }
-
-            return
-
-            mrcal_calibrate_camera(observations, boardWidth, boardHeight, boardSpacing, imageWidth, imageHeight, focalLen);
+        if (!(board_corners.size() == board_corner_levels.size() && board_corners.size() == boardWidth * boardHeight)) {
+            return new MrCalResult(false);
         }
+
+        int i = 0;
+        for (int b = 0; b < board_corners.size(); b++) {
+            var board = board_corners.get(b);
+            var levels = board_corner_levels.get(b).toArray();
+            var corners = board.toArray();
+
+            if (!(corners.length == levels.length && corners.length == boardWidth * boardHeight)) {
+                return new MrCalResult(false);
+            }
+
+            // Assume that we're correct in terms of row/column major-ness (lol)
+            for (int c = 0; c < corners.length; c++) {
+
+                var corner = corners[c];
+                float level = levels[c];
+
+                observations[i * 3 + 0] = corner.x;
+                observations[i * 3 + 1] = corner.y;
+                observations[i * 3 + 2] = level;
+
+                i += 1;
+            }
+        }
+
+        if (i * 3 != observations.length){
+            return new MrCalResult(false);
+        }
+
+        return mrcal_calibrate_camera(observations, boardWidth, boardHeight, boardSpacing, imageWidth, imageHeight, focalLen);
+    }
 }

--- a/src/main/java/org/photonvision/mrcal/MrCalJNI.java
+++ b/src/main/java/org/photonvision/mrcal/MrCalJNI.java
@@ -72,7 +72,7 @@ public class MrCalJNI {
             int imageWidth, int imageHeight, double focalLen) {
         double[] observations = new double[boardWidth * boardHeight * 3 * board_corners.size()];
 
-        if (!(board_corners.size() == board_corner_levels.size() && board_corners.size() == boardWidth * boardHeight)) {
+        if (!(board_corners.size() == board_corner_levels.size())) {
             return new MrCalResult(false);
         }
 


### PR DESCRIPTION
Currently the length of the "images" that are required must equal the number of points on the board. That is not how it should be. Fixed by completely removing the check against board_corners.size() and boardWidth * boardHeight.