### PR TITLE
Avoid massive stack-allocs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -166,7 +166,7 @@ jobs:
         path: ${{ github.workspace }}/build/libs/*.jar
 
   release:
-    needs: [build-host, build-raspi]
+    needs: [build-host, build-raspi, build-windows]
     runs-on: ubuntu-22.04
     steps:
       # Download literally every single artifact. This also downloads client and docs,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       if: github.event_name == 'push'
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: libmrcal-jar-${{ matrix.arch-name }}
         path: |
@@ -103,7 +103,7 @@ jobs:
       env:
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
 
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       name: Upload jar
       with:
         name: libmrcal-jar-pi
@@ -160,7 +160,7 @@ jobs:
         ARTIFACTORY_API_KEY: ${{ secrets.ARTIFACTORY_API_KEY }}
       if: github.event_name == 'push'
 
-    - uses: actions/upload-artifact@master
+    - uses: actions/upload-artifact@v4
       with:
         name: libmrcal-jar-windowsx64
         path: ${{ github.workspace }}/build/libs/*.jar
@@ -171,7 +171,7 @@ jobs:
     steps:
       # Download literally every single artifact. This also downloads client and docs,
       # but the filtering below won't pick these up (I hope)
-      - uses: actions/download-artifact@v2
+      - uses: actions/download-artifact@v4
 
       - run: find
 
@@ -186,7 +186,7 @@ jobs:
         if: github.event_name == 'push'
 
       # Push to actual release, if tagged
-      - uses: softprops/action-gh-release@v1
+      - uses: softprops/action-gh-release@v2
         with:
           files: |
             **/*

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,6 +5,21 @@
   "version": "0.2.0",
   "configurations": [
     {
+      "name": "(gdb) Attach",
+      "type": "cppdbg",
+      "request": "attach",
+      "program": "/home/matt/github/mrcal-java/cmake_build/lib/libmrcal_jni.so",
+      "processId": "${command:pickProcess}",
+      "MIMode": "gdb",
+      "setupCommands": [
+        {
+          "description": "Enable pretty-printing for gdb",
+          "text": "-enable-pretty-printing",
+          "ignoreFailures": true
+        }
+      ]
+    },
+    {
       "name": "Python debug calibrate cameras",
       "type": "debugpy",
       "request": "launch",
@@ -12,8 +27,19 @@
       "console": "integratedTerminal",
       "cwd": "/home/matt/mrcal_debug_tmp/output_will/images-trimmed",
       "args": [
-        "--corners-cache","corners.vnl","--lensmodel","LENSMODEL_OPENCV8","--focal","1200",
-        "--object-spacing","0.03","--object-width-n","18","--object-height-n","13","*.png"
+        "--corners-cache",
+        "corners.vnl",
+        "--lensmodel",
+        "LENSMODEL_OPENCV8",
+        "--focal",
+        "1200",
+        "--object-spacing",
+        "0.03",
+        "--object-width-n",
+        "18",
+        "--object-height-n",
+        "13",
+        "*.png"
       ],
       "justMyCode": false
     },

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,7 +14,6 @@ if (WITH_ASAN)
     add_compile_options(-fsanitize=address -g -Wall -fsanitize=undefined)
 endif ()
 
-
 find_package(JNI)
 if (JNI_FOUND)
     # Fixes odd AWT dependency

--- a/src/mrcal_wrapper.cpp
+++ b/src/mrcal_wrapper.cpp
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) Photon Vision.
- * 
+ *
  * Permission to use, copy, modify, and/or distribute this software for any
  * purpose with or without fee is hereby granted.
  *
@@ -115,7 +115,9 @@ static std::unique_ptr<mrcal_result> mrcal_calibrate(
 
   // Copy from board/point pool above, using some code borrowed from
   // mrcal-pywrap
-  mrcal_observation_board_t c_observations_board[Nobservations_board];
+  std::vector<mrcal_observation_board_t> observations_board_data;
+  observations_board_data.resize(Nobservations_board);
+  auto c_observations_board = observations_board_data.data();
   // Try to make sure we don't accidentally make a zero-length array or
   // something stupid
   mrcal_observation_point_t
@@ -176,8 +178,13 @@ static std::unique_ptr<mrcal_result> mrcal_calibrate(
   // call optimize
 
   // Residuals
-  double c_b_packed_final[Nstate];
-  double c_x_final[Nmeasurements];
+  std::vector<double> b_packed_final;
+  b_packed_final.resize(Nstate);
+  auto c_b_packed_final = b_packed_final.data();
+
+  std::vector<double> x_final;
+  x_final.resize(Nmeasurements);
+  auto c_x_final = x_final.data();
 
   // Seeds
   double *c_intrinsics = intrinsics.data();

--- a/src/mrcal_wrapper.cpp
+++ b/src/mrcal_wrapper.cpp
@@ -115,8 +115,7 @@ static std::unique_ptr<mrcal_result> mrcal_calibrate(
 
   // Copy from board/point pool above, using some code borrowed from
   // mrcal-pywrap
-  std::vector<mrcal_observation_board_t> observations_board_data;
-  observations_board_data.resize(Nobservations_board);
+  std::vector<mrcal_observation_board_t> observations_board_data(Nobservations_board);
   auto c_observations_board = observations_board_data.data();
   // Try to make sure we don't accidentally make a zero-length array or
   // something stupid
@@ -178,12 +177,10 @@ static std::unique_ptr<mrcal_result> mrcal_calibrate(
   // call optimize
 
   // Residuals
-  std::vector<double> b_packed_final;
-  b_packed_final.resize(Nstate);
+  std::vector<double> b_packed_final(Nstate);
   auto c_b_packed_final = b_packed_final.data();
 
-  std::vector<double> x_final;
-  x_final.resize(Nmeasurements);
+  std::vector<double> x_final(Nmeasurements);
   auto c_x_final = x_final.data();
 
   // Seeds


### PR DESCRIPTION
So my code was also allocating a ton. For 588 photos of a 10x10 cal object, I have removed:

- 7KB from c_observations_board
- 28224 bytes from b_packed_final
- 940800 bytes from c_x_final

A quick audit of mrcal shows a good chunk of stack allocations, but nothing on this order of magnitude. Whoops. My bad.